### PR TITLE
Use `assert!` in const

### DIFF
--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -12,8 +12,7 @@ use crate::{
 
 use usb_device::class_prelude::*;
 
-// Const assertion
-const _: [(); 0 - !{ MAX_MSG_LENGTH >= PACKET_SIZE } as usize] = [];
+const _: () = assert!(MAX_MSG_LENGTH >= PACKET_SIZE);
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum State {


### PR DESCRIPTION
This actually works since 1.57 and the previous weird const assertion was not necessary.