### PR TITLE
Fix panics

### DIFF
--- a/src/class.rs
+++ b/src/class.rs
@@ -99,9 +99,9 @@ where
             Some(self.string_index),
         )?;
         writer.write(FUNCTIONAL_INTERFACE, &FUNCTIONAL_INTERFACE_DESCRIPTOR)?;
-        writer.endpoint(&self.pipe.write).unwrap();
-        writer.endpoint(&self.read).unwrap();
-        // writer.endpoint(&self.interrupt).unwrap();
+        writer.endpoint(&self.pipe.write).ok();
+        writer.endpoint(&self.read).ok();
+        // writer.endpoint(&self.interrupt).ok();
         Ok(())
     }
 
@@ -179,7 +179,10 @@ where
                         ClassRequest::GetDataRates => {
                             transfer.accept_with_static(&DATA_RATE_BPS).ok();
                         }
-                        _ => panic!("unexpected direction for {:?}", &request),
+                        _ => {
+                            error!("unexpected direction for {:?}", &request);
+                            self.pipe.reset_state();
+                        }
                     }
                 }
 
@@ -219,7 +222,10 @@ where
                             // transfer.reject().ok();
                             // todo!();
                         }
-                        _ => panic!("unexpected direction for {:?}", &request),
+                        _ => {
+                            error!("unexpected direction for {:?}", &request);
+                            self.pipe.reset_state();
+                        }
                     }
                 }
 

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -6,7 +6,7 @@ use crate::{
     constants::*,
     types::packet::{
         Chain, ChainedPacket as _, Command as PacketCommand, DataBlock, Error as PacketError,
-        ExtPacket, PacketWithData as _, RawPacket, XfrBlock,
+        ExtPacket, PacketWithData as _, RawPacket, RawPacketExt as _, XfrBlock,
     },
 };
 
@@ -385,8 +385,7 @@ where
     pub fn send_wait_extension(&mut self) -> bool {
         if self.state == State::Processing {
             // Need to send a wait extension request.
-            let mut packet = RawPacket::new();
-            packet.resize_default(CCID_HEADER_LEN).ok();
+            let mut packet = RawPacket::zeroed_until(CCID_HEADER_LEN);
             packet[0] = 0x80;
             packet[6] = self.seq;
 
@@ -494,16 +493,14 @@ where
     }
 
     fn send_slot_status_ok(&mut self) {
-        let mut packet = RawPacket::new();
-        packet.resize_default(CCID_HEADER_LEN).ok();
+        let mut packet = RawPacket::zeroed_until(CCID_HEADER_LEN);
         packet[0] = 0x81;
         packet[6] = self.seq;
         self.send_packet_assuming_possible(packet);
     }
 
     fn send_slot_status_error(&mut self, error: Error) {
-        let mut packet = RawPacket::new();
-        packet.resize_default(CCID_HEADER_LEN).ok();
+        let mut packet = RawPacket::zeroed_until(CCID_HEADER_LEN);
         packet[0] = 0x6c;
         packet[6] = self.seq;
         packet[7] = 1 << 6;
@@ -512,8 +509,7 @@ where
     }
 
     fn send_parameters(&mut self) {
-        let mut packet = RawPacket::new();
-        packet.resize_default(17).ok();
+        let mut packet = RawPacket::zeroed_until(17);
         packet[0] = 0x82;
         packet[1] = 7;
         packet[6] = self.seq;

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -98,7 +98,7 @@ where
     /// Reset the state of the CCID driver
     ///
     /// This is done on unexpected input instead of panicking
-    fn reset_state(&mut self) {
+    pub fn reset_state(&mut self) {
         self.seq = 0;
         self.state = State::Idle;
         self.sent = 0;

--- a/src/types/packet.rs
+++ b/src/types/packet.rs
@@ -61,17 +61,20 @@ pub trait PacketWithData: Packet {
     }
 }
 
+#[derive(Debug, Default, Clone, Copy)]
+pub struct UnknownChaining;
+
 pub trait ChainedPacket: Packet {
     #[inline(always)]
-    fn chain(&self) -> Chain {
+    fn chain(&self) -> Result<Chain, UnknownChaining> {
         let level_parameter = u16::from_le_bytes(self[8..10].try_into().unwrap());
         match level_parameter {
-            0 => Chain::BeginsAndEnds,
-            1 => Chain::Begins,
-            2 => Chain::Ends,
-            3 => Chain::Continues,
-            0x10 => Chain::ExpectingMore,
-            _ => panic!("invalid power select parameter"),
+            0 => Ok(Chain::BeginsAndEnds),
+            1 => Ok(Chain::Begins),
+            2 => Ok(Chain::Ends),
+            3 => Ok(Chain::Continues),
+            0x10 => Ok(Chain::ExpectingMore),
+            _ => Err(UnknownChaining),
         }
     }
 }


### PR DESCRIPTION
Instead of panicking, this PR will reset the driver to its initial state.

This should avoid crashing the entire device when encountering an incorrect CCID host implementation.
It should for example fix [the panics encountered with OpenKeychain](https://github.com/Nitrokey/opcard-rs/issues/157) (though not solve the failure to decrypt).